### PR TITLE
Fix encoding time derivation in `test/utest.c' for linux platform.

### DIFF
--- a/test/utest.c
+++ b/test/utest.c
@@ -525,26 +525,18 @@ void print_log(int i_level, const char *psz_fmt, ...)
 #include <windows.h>
 
 typedef DWORD time_clk_t;
-#define CLK_PER_SEC     (1000)
-#define CLK_PER_MSEC    (1)
 #define app_get_time()  clock()
-
 #elif defined(__GNUC__) || defined(ANDROID)
 #include <time.h>
 #include <sys/time.h>
 typedef unsigned long time_clk_t;
-#define CLK_PER_SEC     (10000)
-#define CLK_PER_MSEC    (10)
-static time_clk_t app_get_time(void)
-{
-    time_clk_t t;
-    t = (time_clk_t)(clock()) * 10000L / CLK_PER_SEC;
-    return t;
-}
+#define app_get_time()  clock()
 #else
 #error THIS PLATFORM CANNOT SUPPORT CLOCK.
 #endif
 
+#define CLK_PER_SEC  (CLOCKS_PER_SEC)
+#define CLK_PER_MSEC (CLOCKS_PER_SEC / 1000)
 #define clock_2_msec(clk) \
     ((int)((clk + (CLK_PER_MSEC/2))/CLK_PER_MSEC))
 


### PR DESCRIPTION
In linux platform like ubuntu, the output encoding time is about 100 times larger than the real time.
```
===============================================================================
Encoded frame count               = 17
Total encoding time               = 1871875.000 msec, 1871.875 sec
Average encoding time for a frame = 110110.297 msec
Average encoding speed            = 0.00908 frames/sec
===============================================================================
        Command being timed: "./uavs3enc -w 1280 -h 720 -i /mnt/d/Seq/Crew_1280x720_60.yuv -q 45 --fps_num 60 --fps_den 1 -o /mnt/t/test.avs -f 17 -p 64 -d 8 --alf 1 --affine 1"
        User time (seconds): 18.64
        System time (seconds): 0.32
        Percent of CPU this job got: 100%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:18.90
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 330492
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 83091
        Voluntary context switches: 0
        Involuntary context switches: 0
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

When this patch is applied, the output will be close to the output of time command.
```
===============================================================================
Encoded frame count               = 17
Total encoding time               = 18766.000 msec, 18.766 sec
Average encoding time for a frame = 1103.882 msec
Average encoding speed            = 0.90589 frames/sec
===============================================================================
        Command being timed: "./uavs3enc -w 1280 -h 720 -i /mnt/d/Seq/Crew_1280x720_60.yuv -q 45 --fps_num 60 --fps_den 1 -o /mnt/t/test.avs -f 17 -p 64 -d 8 --alf 1 --affine 1"
        User time (seconds): 18.56
        System time (seconds): 0.31
        Percent of CPU this job got: 100%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:18.87
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 330496
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 83092
        Voluntary context switches: 0
        Involuntary context switches: 0
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```