### PR TITLE
Fix FFmpeg linking error: duplicate name

### DIFF
--- a/inc/com_api.h
+++ b/inc/com_api.h
@@ -43,7 +43,7 @@ extern "C"
 {
 #endif
 
-#define BIT_DEPTH 8
+#define BIT_DEPTH 10
 
 #if (BIT_DEPTH == 8)
     typedef unsigned char     pel; /* pixel type */

--- a/inc/lookahead.h
+++ b/inc/lookahead.h
@@ -53,6 +53,6 @@ double loka_get_sc_ratio(inter_search_t *pi, com_img_t *img_org, com_img_t *img_
 void   loka_slicetype_decision(enc_ctrl_t *h);
 int    check_scenecut_histogram(inter_search_t *pi, analyze_node_t *img_org, int *last_histo_data, int bit_depth);
 int    check_scenecut_histogram_next_gop(enc_ctrl_t *h, int *histo_datat, int cur_scenecut_idx, int max_gop_idx, int bit_depth);
-void   calculate_histogram(inter_search_t *pi, com_img_t *img_org, int *histo_data, int bit_depth);
+void   uavs3e_calculate_histogram(inter_search_t *pi, com_img_t *img_org, int *histo_data, int bit_depth);
 
 #endif //_ENC_LOOKAHEAD_H_

--- a/src/lookahead.c
+++ b/src/lookahead.c
@@ -352,7 +352,7 @@ int check_scenecut_histogram(inter_search_t *pi, analyze_node_t *img_org, int *l
 
     return 0;
 }
-void calculate_histogram(inter_search_t *pi, com_img_t *img_org, int *histo_data, int bit_depth)
+void uavs3e_calculate_histogram(inter_search_t *pi, com_img_t *img_org, int *histo_data, int bit_depth)
 {
     int width_block = img_org->width[0] / HISBLOCK_SIZE;
     int height_block = img_org->height[0] / HISBLOCK_SIZE;

--- a/src/uavs3e.c
+++ b/src/uavs3e.c
@@ -1239,7 +1239,7 @@ static void enc_push_frm(enc_ctrl_t *h, com_img_t *img, int insert_idr)
         h->lastI_ptr = img->ptr;
         h->img_lastIP = img;
         if (h->cfg.scenecut_histogram) {
-            calculate_histogram(&h->pinter, img, h->lastIP_histo_data, h->info.bit_depth_internal);
+            uavs3e_calculate_histogram(&h->pinter, img, h->lastIP_histo_data, h->info.bit_depth_internal);
             h->lastIP_sc_ratio = 0;
         }
         com_img_addref(img);
@@ -1252,7 +1252,7 @@ static void enc_push_frm(enc_ctrl_t *h, com_img_t *img, int insert_idr)
     h->img_rlist[h->img_rsize].img = img;
     h->img_rlist[h->img_rsize].insert_idr = insert_idr;
     if (h->cfg.scenecut_histogram) {
-        calculate_histogram(&h->pinter, img, h->img_rlist[h->img_rsize].histo_data, bit_depth);
+        uavs3e_calculate_histogram(&h->pinter, img, h->img_rlist[h->img_rsize].histo_data, bit_depth);
     }
     h->img_rlist[h->img_rsize].sc_ratio = loka_get_sc_ratio(&h->pinter, img, last_img, bit_depth);
     h->img_rsize++;


### PR DESCRIPTION
Fix FFmpeg linking error: redefine of 'calculate_histogram' by changing its name to uavs3e_calculate_histogram