### PR TITLE
修复程序编码完成而程序无法正常退出的偶现问题

### DIFF
--- a/uAVS3lib/uAVS3lib_gop.c
+++ b/uAVS3lib/uAVS3lib_gop.c
@@ -180,7 +180,7 @@ void avs3gop_lib_free(void *handle)
     avs3gop_t *g = (avs3gop_t *)handle;
  
     for (i = 0; i < g->objs; i++) {
-        avs3_lib_encode(g->obj_list[i].enc, 2, 1);
+        avs3_lib_encode(g->obj_list[i].enc, 1, 1);
         avs3_lib_free(g->obj_list[i].enc);
         com_free(g->obj_list[i].strm_buf);
     }


### PR DESCRIPTION
exit_flag作为lookahead/encoding线程的退出标志，主线程对该flag的更新会存在竞争。在reset时，会发生lookahead线程未进入循环而encoding线程进入循环的情况，使程序无法正常退出。仅使用flush帧作为线程退出的单一标志可解决该问题。